### PR TITLE
Corrections and adaptations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ where:
 * revisionHead if true (and exportVersion=true) then files are exported with head (latest) revision numbered, if set to false then the default numbering scheme used by the Alfresco Bulk Import tool is used (head revision is not numbered) - parameter **optional**, only used if exportVersion set, The default is _false_.
 * useNodeCache if true then a list of nodes to export is cached to the export area for future repeated use. Sometimes useful for large exports of data due to the transaction cache being full - parameter **optional**, The default is _false_.
 * nbOfThreads number of threads in the thread pool if none is given the default value is 1
-* nbOfTasks is the number or Callable instances, this means the total number of nodes is equally dispatched between the tasks, if none is given the default value is 2
 * exportChunkSize is the number of Nodes handled by each Task iteration. Default value is 10
 
 When the export is ended you will see in browser a message _"Process finished Successfully"_. Once this message is printed, look-up your content in the Alfresco Server in the {base} directory.

--- a/src/main/java/org/alfresco/extensions/bulkexport/controler/Engine.java
+++ b/src/main/java/org/alfresco/extensions/bulkexport/controler/Engine.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 
 /**
@@ -184,6 +185,7 @@ public class Engine {
      */
     private void exportNodes(final List<NodeRef> nodesToExport) throws InterruptedException, ExecutionException {
         ExecutorService threadPool = Executors.newFixedThreadPool(nbOfThreads);
+        List<Future<?>> futures = new ArrayList<>();
 
         int previousLowerLimitNodeNumber = 0;
         int noOfTasks = new Double(Math.ceil(nodesToExport.size() / this.exportChunkSize)).intValue();
@@ -199,8 +201,15 @@ public class Engine {
             previousLowerLimitNodeNumber = upperLimitNodeNumber;
 
             List<NodeRef> nodesForCurrentThread = nodesToExport.subList(lowerLimitNodeNumber, upperLimitNodeNumber);
-            threadPool.submit(new NodeExportTask(nodesForCurrentThread, exportVersions, revisionHead, dao, fileFolder, taskNumber));
+            futures.add(threadPool.submit(new NodeExportTask(nodesForCurrentThread, exportVersions, revisionHead, dao, fileFolder, taskNumber)));
         }
+
+        boolean exportTerminated = false;
+
+        for (Future<?> future : futures) {
+            exportTerminated &= future.isDone();
+        }
+
     }
 
     private int calculateNextLowerLimitNodeNumber(int previousLowerLimitNodeNumber, int upperLimitNodeNumber) {

--- a/src/main/java/org/alfresco/extensions/bulkexport/controler/Engine.java
+++ b/src/main/java/org/alfresco/extensions/bulkexport/controler/Engine.java
@@ -188,7 +188,7 @@ public class Engine {
         List<Future<?>> futures = new ArrayList<>();
 
         int previousLowerLimitNodeNumber = 0;
-        int noOfTasks = new Double(Math.ceil(nodesToExport.size() / this.exportChunkSize)).intValue();
+        int noOfTasks = new Double(Math.ceil((double) nodesToExport.size() / (double) this.exportChunkSize)).intValue();
 
         log.info("Number of tasks: " + noOfTasks);
 


### PR DESCRIPTION
-Depending on numbers that were given, they were rounded because the division always returned an int.
-Futures help better manage multithreading
-Documentation change since the nbOfTasks is no more valid